### PR TITLE
Add ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,67 @@
+name: Go CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+      - 'feat/**'
+
+jobs:
+  # 静的解析
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ^1.20
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60
+          args: --timeout=5m
+      
+      - name: Run test coverage
+        run: go test -v ./...
+
+  # テスト
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '^1.20'
+
+      - name: Run tests and generate coverage report
+        run: go test -v -coverprofile=coverage.out ./...
+
+  # ビルド
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '^1.20'
+
+      - name: Run go mod tidy and check for changes
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum || { echo "go.mod or go.sum has uncommitted changes. Please run 'go mod tidy' and commit."; exit 1; }
+
+      - name: Build application
+        run: go build -v ./...


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automating CI processes in a Go project. The workflow includes separate jobs for linting, testing, and building the application, ensuring code quality and reliability.

### CI Workflow Setup:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR1-R67): Added a new GitHub Actions workflow named "Go CI," triggered on `pull_request` and `push` events to `main` and `feat/**` branches.

### Linting:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR1-R67): Configured a `lint` job to run `golangci-lint` for static code analysis with a timeout of 5 minutes.

### Testing:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR1-R67): Configured a `test` job to execute Go tests with verbose output and generate a coverage report using `go test -coverprofile`.

### Building:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR1-R67): Configured a `build` job to run `go mod tidy` and verify no uncommitted changes in `go.mod` or `go.sum`, followed by building the application with `go build`.